### PR TITLE
Update for policy file suppport

### DIFF
--- a/delivery/project.toml
+++ b/delivery/project.toml
@@ -1,6 +1,6 @@
 [local_phases]
-unit = "rspec spec/"
-lint = 'cookstyle --display-cop-names --extra-details'
+unit = "chef exec rspec spec/"
+lint = "chef exec cookstyle --display-cop-names --extra-details"
 syntax = "echo syntax checking with foodcritic has been replaced with cookstyle. skipping"
 provision = "echo skipping"
 deploy = "echo skipping"


### PR DESCRIPTION
### Description

current delivery config creates an error about missing berks file when ran on cookbooks with policy files

### Issues Resolved
NA

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>